### PR TITLE
Added iPhone 5 Web Grid resource to ## Setup for Retina Mockups

### DIFF
--- a/photoshop-handbook/Readme.md
+++ b/photoshop-handbook/Readme.md
@@ -33,6 +33,8 @@ Mockups should be created at 2× resolution by default. This can make thinking i
 
 Note: some palettes and inputs (such as Transform) do not respect the unit preferences. However, they do remember the last unit used so as you work in points they will come to reflect the new preferred unit.
 
+### Resources for creating Mocks
+* [iPhone 5 Web Grid (PSD)](https://www.dropbox.com/s/6944ymdxx7kotp6/iphone5-web-grid.psd?dl=1)
 
 ## Modules & Linked Smart Objects
 

--- a/photoshop-handbook/Readme.md
+++ b/photoshop-handbook/Readme.md
@@ -33,7 +33,7 @@ Mockups should be created at 2× resolution by default. This can make thinking i
 
 Note: some palettes and inputs (such as Transform) do not respect the unit preferences. However, they do remember the last unit used so as you work in points they will come to reflect the new preferred unit.
 
-### Resources for creating Mocks
+### Resources for Creating Mocks
 * [iPhone 5 Web Grid (PSD)](https://www.dropbox.com/s/6944ymdxx7kotp6/iphone5-web-grid.psd?dl=1)
 
 ## Modules & Linked Smart Objects


### PR DESCRIPTION
Added a resources section to the Setup for Retina Mockups with a new resource: iPhone 5 Web Grid.
The PSD includes:
- Basic instructions on how to use the document
- Grid with 16px gutters to make an equidistant grid on a 320px wide screen.
- Mobile Safari chrome overlay
- Native keyboard overlay 

The document is setup using the instructions put forth in the "Setup for Retina Mockups" section.

Status: **Merged**

Reviewers: @kpeatt @jeffkamo @ry5n 
Ticket: N/A
Linked PRs: N/A
## Changes
- Add section **Resources for creating Mocks**
## How to test-drive this PR
- Review the text
- Download the linked iPhone 5 Web Grid (PSD)
